### PR TITLE
Fixed hours evaluation

### DIFF
--- a/adhd-away.user.js
+++ b/adhd-away.user.js
@@ -25,7 +25,7 @@ var evening_hour	= 23;
 
 var body = document.getElementsByTagName( "body" )[0];
 
-if ((hours <= morning_hour) || (hours => evening_hour)) {
+if ((hours >= morning_hour) || (hours <= evening_hour)) {
     console.log("HEYEYEYEYAA");
 	body.innerHTML = "";
 	document.getElementsByTagName( "head" )[0].innerHTML = "";


### PR DESCRIPTION
`hours >= evening_hour` evaluates to `function (hours) { return evening_hour }`, which will always return `true`, given `evening_hour` is a positive number. This means that the block will always apply, regardless of time. This is because `=>` is an arrow function rather than a comparison operator.

Further, the evaluations were backwards and would block content before `morning_hour` and after `evening_hour`, rather than the other way around.